### PR TITLE
Update plugin name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then you need to configure babel to run the transform.  For example, if you were
   "transform": [[
     "babelify", {
       "presets": ["es2015"],
-      "plugins": ["babel-plugin-glslify"]
+      "plugins": ["glslify"]
     }
   ]]
 }


### PR DESCRIPTION
PS Now that you have renamed the plugin (thank you for that!) we can change
      "plugins": ["babel-plugin-glslify"]
to
      "plugins": ["glslify"]
Which makes this feel nicely integrated into the babel system.
