### PR TITLE
do path resolution on the filename rather than the inlined shader string

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [babel](https://babeljs.io/) transform for [glslify](https://github.com/stackg
 This module works the same as the browserify transform in [glslify](https://github.com/stackgl/glslify), except that it is compatible with babel.  It also supports ES6 syntax and some more advanced features like tagged strings.  For example, you can write something like this,
 
 ```javascript
-import glsl from glslify;
+import glsl from "glslify";
 
 const myFragShader = glsl`
 #pragma glslify: noise = require(glsl-noise/simplex/2d)

--- a/lib/glslify-sync-hack.js
+++ b/lib/glslify-sync-hack.js
@@ -15,9 +15,9 @@ module.exports = function (baseDir, stringInput, optionInput) {
   }
 
   if (optionInput.inline) {
-    glslifyInput.data = path.resolve(stringInput)
+    glslifyInput.data = stringInput
   } else {
-    glslifyInput.filename = stringInput
+    glslifyInput.filename = path.resolve(stringInput)
   }
 
   var options = {


### PR DESCRIPTION
fixes a bug where inlined shaders were turned into something like:

```
#define GLSLIFY 1
/Users/cambecc/code/sample
void main() {}
```

...because the inlined shader string was being resolved like a filename.
