### PR TITLE
Remove unnecessary argument to toString.

### DIFF
--- a/lib/glslify-sync-hack.js
+++ b/lib/glslify-sync-hack.js
@@ -28,5 +28,5 @@ module.exports = function (baseDir, stringInput, optionInput) {
     input: JSON.stringify(glslifyInput)
   }
 
-  return execFileSync(process.argv[0], [SCRIPT_PATH], options).toString(0)
+  return execFileSync(process.argv[0], [SCRIPT_PATH], options).toString()
 }


### PR DESCRIPTION
 Fixes https://github.com/stackgl/babel-plugin-glslify/issues/8 for node 8.

It appears the argument to `toString` is no longer necessary, as it will set `begin` to 0 if no argument is provided, and the first argument should be an encoding now anyways.

Wanted to start a conversation about this, haven't tested yet with earlier versions of node.